### PR TITLE
CMake: Updated OpenSSL macro to find 32/64bit libraries in default path.

### DIFF
--- a/cmake/macros/FindOpenSSL.cmake
+++ b/cmake/macros/FindOpenSSL.cmake
@@ -45,6 +45,7 @@ IF(PLATFORM EQUAL 64)
   SET(_OPENSSL_ROOT_PATHS
     "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (64-bit)_is1;InstallLocation]"
     "C:/OpenSSL-Win64/"
+	"C:/Program Files/OpenSSL-Win64/"
     "C:/OpenSSL/"
   )
 ELSE()
@@ -52,6 +53,7 @@ ELSE()
     "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (32-bit)_is1;InstallLocation]"
     "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (32-bit)_is1;InstallLocation]"
     "C:/OpenSSL-Win32/"
+	"C:/Program Files (x86)/OpenSSL-Win32/"
     "C:/OpenSSL/"
   )
 ENDIF()


### PR DESCRIPTION
Updated to cater for default windows installation paths.