### PR TITLE
Fix Mindless Zombie removing npcflag

### DIFF
--- a/sql/updates/world/2020_09_13_00_world.sql
+++ b/sql/updates/world/2020_09_13_00_world.sql
@@ -1,0 +1,1 @@
+UPDATE `world`.`creature_template` SET `npcflag`='0' WHERE  `entry`=1501;

--- a/sql/updates/world/2020_09_13_00_world.sql
+++ b/sql/updates/world/2020_09_13_00_world.sql
@@ -1,1 +1,1 @@
-UPDATE `world`.`creature_template` SET `npcflag`='0' WHERE  `entry`=1501;
+UPDATE `creature_template` SET `npcflag`='0' WHERE  `entry`=1501;


### PR DESCRIPTION
https://classic.wowhead.com/npc=1501/mindless-zombie in Undead starting zone is randomly flagged as quest givers.