### PR TITLE
Update event_flags in smart_scripts table

### DIFF
--- a/sql/updates/world/2020_09_14_00_world.sql
+++ b/sql/updates/world/2020_09_14_00_world.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `smart_scripts`
+	CHANGE COLUMN `event_flags` `event_flags` SMALLINT UNSIGNED NOT NULL DEFAULT 0 AFTER `event_chance`;


### PR DESCRIPTION
event_flags range from 1-512 (see documentation: https://trinitycore.atlassian.net/wiki/spaces/tc/pages/2130108/smart+scripts)
event_flags currently TINYINT, must be at least SMALLINT