### PR TITLE
Correct name of Glyph of Cheap Shot in DB

### DIFF
--- a/sql/updates/world/2020_09_16_01_world.sql
+++ b/sql/updates/world/2020_09_16_01_world.sql
@@ -1,0 +1,1 @@
+UPDATE `item_template` SET `name`='Glyph of Cheap Shot' WHERE  `entry`=42969;


### PR DESCRIPTION
Glyph of Cheap Shot is currently named Glyph of Rupture in DB