### PR TITLE
Fix Quest requirement for The Lesson of the Burning Scroll

### DIFF
--- a/sql/updates/world/2021_05_11_00_world.sql
+++ b/sql/updates/world/2021_05_11_00_world.sql
@@ -1,0 +1,1 @@
+UPDATE `gameobject_template` SET `unkInt32` = '2' WHERE (`entry` = '210986');


### PR DESCRIPTION
Changed the level requirement for burning the scroll from 172 to 2.