### PR TITLE
Core/Spells Implement SPELL_ATTR8_COMBAT_RESURECTION_LIMIT

### DIFF
--- a/sql/updates/world/2021_08_02_00_world.sql
+++ b/sql/updates/world/2021_08_02_00_world.sql
@@ -1,0 +1,2 @@
+DELETE FROM `spell_script_names` WHERE `spell_id`=106922 AND `ScriptName`='spell_dru_might_of_ursoc';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (106922, 'spell_dru_might_of_ursoc');

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11205,6 +11205,9 @@ int32 Unit::CalcSpellDuration(SpellInfo const* spellProto)
     else
         duration = minduration;
 
+    if (spellProto->Id == 5171)
+        duration = minduration + (minduration * comboPoints);
+
     return duration;
 }
 

--- a/src/server/game/Miscellaneous/SharedDefines.h
+++ b/src/server/game/Miscellaneous/SharedDefines.h
@@ -650,7 +650,7 @@ enum SpellAttr8
     SPELL_ATTR8_ARMOR_SPECIALIZATION             = 0x00100000, // 20
     SPELL_ATTR8_UNK21                            = 0x00200000, // 21
     SPELL_ATTR8_UNK22                            = 0x00400000, // 22
-    SPELL_ATTR8_UNK23                            = 0x00800000, // 23
+    SPELL_ATTR8_COMBAT_RESURECTION_LIMIT         = 0x00800000, // 23
     SPELL_ATTR8_HEALING_SPELL                    = 0x01000000, // 24
     SPELL_ATTR8_UNK25                            = 0x02000000, // 25
     SPELL_ATTR8_RAID_MARKER                      = 0x04000000, // 26 probably spell no need learn to cast

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1245,8 +1245,28 @@ void Aura::HandleAuraSpecificMods(AuraApplication const* aurApp, Unit* caster, b
                     case 5215:   // Prowl
                     {
                         // check for catform
-                        if (!caster->HasAura(768))
+                        if (caster->GetShapeshiftForm() != FORM_CAT)
                             caster->CastSpell(caster, 768, true);
+                        break;
+                    }
+                    case 106898: // Stampeding Roar
+                    {
+                        // activates bear form
+                        caster->CastSpell(caster, 5487, true);
+                        target->RemoveMovementImpairingAuras();
+                        break;
+                    }
+                    case 77761: // Stampeding roar Bearform
+                    case 77764: // Stampeding roar Catform
+                    {
+                        target->RemoveMovementImpairingAuras();
+                        break;
+                    }
+                    case 102795: // Bear Hug
+                    {
+                        // check for bear form
+                        if (caster->GetShapeshiftForm() != FORM_BEAR)
+                            caster->CastSpell(caster, 5487, true); // activate bear form
                         break;
                     }
                     break;
@@ -1457,6 +1477,16 @@ void Aura::HandleAuraSpecificMods(AuraApplication const* aurApp, Unit* caster, b
                 if (GetSpellInfo()->SpellFamilyFlags[0] & 0x00000008)
                     if (caster && caster->HasAura(56845))
                         target->CastSpell(target, 61394, true);
+                break;
+            case SPELLFAMILY_DRUID:
+                switch (m_spellInfo->Id)
+                {
+                    case 768: // catform
+                        // remove prowl when leaving catform
+                        if (caster->HasAura(5215))
+                            caster->RemoveOwnedAura(5215);
+                        break;
+                }
                 break;
         }
     }

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -4386,8 +4386,20 @@ void Spell::EffectResurrect(SpellEffIndex effIndex)
     if (target->IsRessurectRequested())       // already have one active request
         return;
 
-    uint32 health = target->CountPctFromMaxHealth(damage);
-    uint32 mana   = CalculatePct(target->GetMaxPower(POWER_MANA), damage);
+    uint32 health = 0;
+    uint32 mana = 0;
+
+    // check for spells that use different health and mana % on some resurrection
+    if (m_spellInfo->AttributesEx8 & SPELL_ATTR8_COMBAT_RESURECTION_LIMIT)
+    {
+        health = target->CountPctFromMaxHealth(m_spellInfo->Effects[EFFECT_1].BasePoints);
+        mana = CalculatePct(target->GetMaxPower(POWER_MANA), m_spellInfo->Effects[EFFECT_0].BasePoints);       
+    }
+    else 
+    {
+        health = target->CountPctFromMaxHealth(damage);
+        mana = CalculatePct(target->GetMaxPower(POWER_MANA), damage);
+    }
 
     ExecuteLogEffectResurrect(effIndex, target);
 
@@ -4528,18 +4540,27 @@ void Spell::EffectSelfResurrect(SpellEffIndex effIndex)
     uint32 health = 0;
     uint32 mana = 0;
 
-    // flat case
-    if (damage < 0)
+    // check for spells that use different health and mana % on some battle resurrection
+    if (m_spellInfo->AttributesEx8 & SPELL_ATTR8_COMBAT_RESURECTION_LIMIT)
     {
-        health = uint32(-damage);
-        mana = m_spellInfo->Effects[effIndex].MiscValue;
+        health = m_caster->CountPctFromMaxHealth(m_spellInfo->Effects[EFFECT_1].BasePoints);
+        mana = CalculatePct(m_caster->GetMaxPower(POWER_MANA), m_spellInfo->Effects[EFFECT_0].BasePoints);
     }
-    // percent case
     else
     {
-        health = m_caster->CountPctFromMaxHealth(damage);
-        if (m_caster->GetMaxPower(POWER_MANA) > 0)
-            mana = CalculatePct(m_caster->GetMaxPower(POWER_MANA), damage);
+        // flat case
+        if (damage < 0)
+        {
+            health = uint32(-damage);
+            mana = m_spellInfo->Effects[effIndex].MiscValue;
+        }
+        // percent case
+        else
+        {
+            health = m_caster->CountPctFromMaxHealth(damage);
+            if (m_caster->GetMaxPower(POWER_MANA) > 0)
+                mana = CalculatePct(m_caster->GetMaxPower(POWER_MANA), damage);
+        }
     }
 
     Player* player = m_caster->ToPlayer();

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -56,7 +56,8 @@ enum DruidSpells
     SPELL_DRUID_STAMPEDE_BAER_RANK_1        = 81016,
     SPELL_DRUID_STAMPEDE_CAT_RANK_1         = 81021,
     SPELL_DRUID_STAMPEDE_CAT_STATE          = 109881,
-    SPELL_DRUID_TIGER_S_FURY_ENERGIZE       = 51178
+    SPELL_DRUID_TIGER_S_FURY_ENERGIZE       = 51178,
+    SPELL_DRUID_BEAR_FORM                   = 5487,
 };
 
 // 1850 - Dash
@@ -541,6 +542,49 @@ public:
     }
 };
 
+// 106922 - Might of Ursoc
+class spell_dru_might_of_ursoc: public SpellScriptLoader
+{
+public:
+    spell_dru_might_of_ursoc() : SpellScriptLoader("spell_dru_might_of_ursoc") { }
+
+    class spell_dru_might_of_ursoc_AuraScript : public AuraScript
+    {
+        PrepareAuraScript(spell_dru_might_of_ursoc_AuraScript);
+
+        bool Validate(SpellInfo const* /*spellInfo*/) override
+        {
+            if (!sSpellMgr->GetSpellInfo(SPELL_DRUID_BEAR_FORM))
+                return false;
+            return true;
+        }
+
+        void CalculateAmount(AuraEffect const* aurEff, int32& amount, bool& /*canBeRecalculated*/)
+        {
+            if (Unit* caster = GetCaster())
+            {
+                // cast bear form first
+                if (caster->GetShapeshiftForm() != FORM_BEAR)
+                    caster->CastSpell(caster, SPELL_DRUID_BEAR_FORM, true); // activate bear form
+                // then calculate amount
+                amount = aurEff->GetBase()->GetUnitOwner()->CountPctFromMaxHealth(amount);
+            }
+ 
+        }
+
+        void Register() override
+        {
+            DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_dru_might_of_ursoc_AuraScript::CalculateAmount, EFFECT_0, SPELL_AURA_MOD_INCREASE_HEALTH_2);
+        }
+    };
+
+    AuraScript* GetAuraScript() const
+    {
+        return new spell_dru_might_of_ursoc_AuraScript();
+    }
+
+};
+
 // -16972 - Predatory Strikes
 class spell_dru_predatory_strikes : public SpellScriptLoader
 {
@@ -945,6 +989,7 @@ void AddSC_druid_spell_scripts()
     new spell_dru_lifebloom();
     new spell_dru_living_seed();
     new spell_dru_living_seed_proc();
+    new spell_dru_might_of_ursoc();
     new spell_dru_predatory_strikes();
     new spell_dru_savage_defense();
     new spell_dru_savage_roar();


### PR DESCRIPTION
- fix an issue where some battle resurrection spells were using the wrong effect basepoints for health and mana calculations