### PR TITLE
fix (Core/CalcSpellDuration) combo-point duration based spells

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11201,12 +11201,14 @@ int32 Unit::CalcSpellDuration(SpellInfo const* spellProto)
     int32 duration;
 
     if (comboPoints && minduration != -1 && minduration != maxduration)
-        duration = minduration + int32((maxduration - minduration) * comboPoints / 5);
+    {
+        if (minduration)
+            duration = minduration + (minduration * comboPoints);
+        else
+            duration = minduration + int32((maxduration - minduration) * comboPoints / 5);
+    }
     else
         duration = minduration;
-
-    if (spellProto->Id == 5171)
-        duration = minduration + (minduration * comboPoints);
 
     return duration;
 }

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1334,9 +1334,6 @@ void AuraEffect::HandleShapeshiftBoosts(Unit* target, bool apply) const
             switch (GetMiscValue())
             {
                 case FORM_CAT:
-                    // Savage Roar
-                    if (target->GetAuraEffect(SPELL_AURA_DUMMY, SPELLFAMILY_DRUID, 0, 0x10000000, 0))
-                        target->CastSpell(target, 62071, true);
                     // Nurturing Instinct
                     if (AuraEffect const* aurEff = target->GetAuraEffect(SPELL_AURA_MOD_SPELL_HEALING_OF_STAT_PERCENT, SPELLFAMILY_DRUID, 2254, EFFECT_0))
                     {

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -710,7 +710,6 @@ public:
                     savageRoar->SetDuration(duration);
                 }
             }
-
         }
 
         void Register() override


### PR DESCRIPTION
- There was an issue with the way spells using the combo-point system was calculating the duration per combo-point.

It appears the minimum duration for such spells is the increment amount for the next combo-point duration (for spells that have a minimum duration). However, the calculation seemed to skew slice and dice whenever patch 5.0.4 was introduced (Mists of Pandaria Patch 5.0.4 (2012-08-28): Duration increased from 9/12/15/18/21 sec to 12/18/24/30/36 sec.
). As such, a new check had to be introduced and calculate for such occurrences.

The culprit seemed to lie with savage roar being the outlier, not using minimum duration as the increment amount. As a result, the calculation check was added and savage roar aurascript properly scripted to set the proper duration amount per combo-point.

- Remove duplicate cast of savage roar trigger
- Remove previous commit fix for slice and dice