### PR TITLE
Druid PR Spell Fixes - Ongoing

### DIFF
--- a/sql/updates/world/2022_06_18_00_world.sql
+++ b/sql/updates/world/2022_06_18_00_world.sql
@@ -1,0 +1,2 @@
+DELETE FROM `spell_script_names` WHERE `spell_id`=5217 AND `ScriptName`='spell_dru_tigers_fury';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (5217, 'spell_dru_tigers_fury');

--- a/sql/updates/world/2022_06_19_00_world.sql
+++ b/sql/updates/world/2022_06_19_00_world.sql
@@ -1,0 +1,2 @@
+DELETE FROM `spell_script_names` WHERE `spell_id`=33763 AND `ScriptName`='spell_dru_lifebloom';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (33763, 'spell_dru_lifebloom');

--- a/sql/updates/world/2022_06_20_00_world.sql
+++ b/sql/updates/world/2022_06_20_00_world.sql
@@ -1,0 +1,2 @@
+DELETE FROM `spell_script_names` WHERE `spell_id`=1850 AND `ScriptName`='spell_dru_dash';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (1850, 'spell_dru_dash');

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1845,6 +1845,11 @@ void AuraEffect::HandleAuraModShapeshift(AuraApplication const* aurApp, uint8 mo
 
     if (target->getClass() == CLASS_DRUID)
     {
+
+        // Dash
+        if (AuraEffect* aurEff = target->GetAuraEffect(SPELL_AURA_MOD_SPEED_ALWAYS, SPELLFAMILY_DRUID, 0, 0, 0x8))
+            aurEff->RecalculateAmount();
+
         // Disarm handling
         // If druid shifts while being disarmed we need to deal with that since forms aren't affected by disarm
         // and also HandleAuraModDisarm is not triggered

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1240,7 +1240,6 @@ void Aura::HandleAuraSpecificMods(AuraApplication const* aurApp, Unit* caster, b
 
                 switch (m_spellInfo->Id)
                 {
-                    case 1850:   // Dash
                     case 137452: // Displacer Beast
                     case 5215:   // Prowl
                     {

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -31,36 +31,36 @@
 
 enum DruidSpells
 {
-    SPELL_DRUID_WRATH                       = 5176,
-    SPELL_DRUID_STARFIRE                    = 2912,
-    SPELL_DRUID_STARSURGE                   = 78674,
+    SPELL_DRUID_BEAR_FORM                   = 5487,
+    SPELL_DRUID_BERSERK_AURA                = 106951,
+    SPELL_DRUID_CAT_FORM                    = 768,
     SPELL_DRUID_ECLIPSE_GENERAL_ENERGIZE    = 89265,
-    SPELL_DRUID_STARSURGE_ENERGIZE          = 86605,
-    SPELL_DRUID_LUNAR_ECLIPSE_MARKER        = 67484, // Will make the yellow arrow on eclipse bar point to the blue side (lunar)
-    SPELL_DRUID_SOLAR_ECLIPSE_MARKER        = 67483, // Will make the yellow arrow on eclipse bar point to the yellow side (solar)
-    SPELL_DRUID_SOLAR_ECLIPSE               = 48517,
-    SPELL_DRUID_LUNAR_ECLIPSE               = 48518,
     SPELL_DRUID_FERAL_CHARGE_BEAR           = 16979,
     SPELL_DRUID_FERAL_CHARGE_CAT            = 49376,
     SPELL_DRUID_GLYPH_OF_INNERVATE          = 54833,
     SPELL_DRUID_GLYPH_OF_STARFIRE           = 54846,
     SPELL_DRUID_INCREASED_MOONFIRE_DURATION = 38414,
-    SPELL_DRUID_LIFEBLOOM_FINAL_HEAL        = 33778,
     SPELL_DRUID_LIFEBLOOM                   = 33763,
+    SPELL_DRUID_LIFEBLOOM_FINAL_HEAL        = 33778,
     SPELL_DRUID_LIVING_SEED_HEAL            = 48503,
     SPELL_DRUID_LIVING_SEED_PROC            = 48504,
+    SPELL_DRUID_LUNAR_ECLIPSE               = 48518,
+    SPELL_DRUID_LUNAR_ECLIPSE_MARKER        = 67484, // Will make the yellow arrow on eclipse bar point to the blue side (lunar)
     SPELL_DRUID_NATURES_GRACE               = 16880,
     SPELL_DRUID_NATURES_GRACE_TRIGGER       = 16886,
+    SPELL_DRUID_WRATH                       = 5176,
+    SPELL_DRUID_STARFIRE                    = 2912,
+    SPELL_DRUID_STARSURGE                   = 78674,
+    SPELL_DRUID_STARSURGE_ENERGIZE          = 86605, 
+    SPELL_DRUID_SOLAR_ECLIPSE_MARKER        = 67483, // Will make the yellow arrow on eclipse bar point to the yellow side (solar)
+    SPELL_DRUID_SOLAR_ECLIPSE               = 48517,
     SPELL_DRUID_SURVIVAL_INSTINCTS          = 50322,
     SPELL_DRUID_SAVAGE_ROAR                 = 52610,
     SPELL_DRUID_SAVAGE_ROAR_TRIGGER         = 62071,
     SPELL_DRUID_STAMPEDE_BAER_RANK_1        = 81016,
     SPELL_DRUID_STAMPEDE_CAT_RANK_1         = 81021,
-    SPELL_DRUID_STAMPEDE_CAT_STATE          = 109881,
-    SPELL_DRUID_BERSERK_AURA                = 106951,
-    SPELL_DRUID_TIGER_S_FURY_ENERGIZE       = 51178,
-    SPELL_DRUID_BEAR_FORM                   = 5487,
-    SPELL_DRUID_CAT_FORM                    = 768,
+    SPELL_DRUID_STAMPEDE_CAT_STATE          = 109881, 
+    SPELL_DRUID_TIGER_S_FURY_ENERGIZE       = 51178,   
 };
 
 // 5217 - Tiger's Fury
@@ -1085,7 +1085,6 @@ public:
 
 void AddSC_druid_spell_scripts()
 {
-    new spell_dru_tigers_fury();
     new spell_dru_dash();
     new spell_dru_eclipse("spell_dru_eclipse_lunar");
     new spell_dru_eclipse("spell_dru_eclipse_solar");
@@ -1105,5 +1104,6 @@ void AddSC_druid_spell_scripts()
     new spell_dru_stampede();
     new spell_dru_survival_instincts();
     new spell_dru_swift_flight_passive();
+    new spell_dru_tigers_fury();
     new spell_dru_t10_restoration_4p_bonus();
 }

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -60,6 +60,7 @@ enum DruidSpells
     SPELL_DRUID_BERSERK_AURA                = 106951,
     SPELL_DRUID_TIGER_S_FURY_ENERGIZE       = 51178,
     SPELL_DRUID_BEAR_FORM                   = 5487,
+    SPELL_DRUID_CAT_FORM                    = 768,
 };
 
 // 5217 - Tiger's Fury
@@ -117,16 +118,37 @@ public:
     {
         PrepareAuraScript(spell_dru_dash_AuraScript);
 
+        bool Validate(SpellInfo const* /*spellInfo*/) override
+        {
+            if (!sSpellMgr->GetSpellInfo(SPELL_DRUID_CAT_FORM))
+                return false;
+            return true;
+        }
+
+        void OnApply(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
+        {
+            if (Unit* caster = GetCaster())
+            {
+                if (!caster->HasAura(SPELL_DRUID_CAT_FORM))
+                {
+                    caster->CastSpell(caster, SPELL_DRUID_CAT_FORM, true);
+                }
+            }
+        }
+
         void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
         {
             // do not set speed if not in cat form
             if (GetUnitOwner()->GetShapeshiftForm() != FORM_CAT)
+            {
                 amount = 0;
+            }
         }
 
         void Register() override
         {
             DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_dru_dash_AuraScript::CalculateAmount, EFFECT_0, SPELL_AURA_MOD_SPEED_ALWAYS);
+            OnEffectApply += AuraEffectApplyFn(spell_dru_dash_AuraScript::OnApply, EFFECT_0, SPELL_AURA_MOD_SPEED_ALWAYS, AURA_EFFECT_HANDLE_REAL_OR_REAPPLY_MASK);
         }
     };
 

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -126,7 +126,7 @@ public:
 
         void Register() override
         {
-            DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_dru_dash_AuraScript::CalculateAmount, EFFECT_0, SPELL_AURA_MOD_INCREASE_SPEED);
+            DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_dru_dash_AuraScript::CalculateAmount, EFFECT_0, SPELL_AURA_MOD_SPEED_ALWAYS);
         }
     };
 

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -58,8 +58,54 @@ enum DruidSpells
     SPELL_DRUID_STAMPEDE_BAER_RANK_1        = 81016,
     SPELL_DRUID_STAMPEDE_CAT_RANK_1         = 81021,
     SPELL_DRUID_STAMPEDE_CAT_STATE          = 109881,
+    SPELL_DRUID_BERSERK_AURA                = 106951,
     SPELL_DRUID_TIGER_S_FURY_ENERGIZE       = 51178,
     SPELL_DRUID_BEAR_FORM                   = 5487,
+};
+
+// 5217 - Tiger's Fury
+class spell_dru_tigers_fury : public SpellScriptLoader
+{
+public:
+    spell_dru_tigers_fury() : SpellScriptLoader("spell_dru_tigers_fury") { }
+
+    class spell_dru_tigers_fury_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_dru_tigers_fury_SpellScript);
+
+        bool Validate(SpellInfo const* /*spellInfo*/) override
+        {
+            if (!sSpellMgr->GetSpellInfo(SPELL_DRUID_BERSERK_AURA))
+                return false;
+            return true;
+        }
+
+        SpellCastResult CheckCast()
+        {
+            if (Unit* caster = GetCaster())
+            {
+                if (caster->GetShapeshiftForm() != FORM_CAT)
+                {
+                    SetCustomCastResultMessage(SPELL_CUSTOM_ERROR_MUST_BE_IN_CAT_FORM);
+                    return SpellCastResult::SPELL_FAILED_CUSTOM_ERROR;
+                }
+
+                if (caster->HasAura(SPELL_DRUID_BERSERK_AURA))
+                    return SpellCastResult::SPELL_FAILED_DONT_REPORT;
+            }
+            return SpellCastResult::SPELL_CAST_OK;
+        }
+
+        void Register() override
+        {
+            OnCheckCast += SpellCheckCastFn(spell_dru_tigers_fury_SpellScript::CheckCast);
+        }
+    };
+
+    SpellScript* GetSpellScript() const
+    {
+        return new spell_dru_tigers_fury_SpellScript();
+    }
 };
 
 // 1850 - Dash
@@ -1020,6 +1066,7 @@ public:
 
 void AddSC_druid_spell_scripts()
 {
+    new spell_dru_tigers_fury();
     new spell_dru_dash();
     new spell_dru_eclipse("spell_dru_eclipse_lunar");
     new spell_dru_eclipse("spell_dru_eclipse_solar");

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -45,7 +45,6 @@ enum DruidSpells
     SPELL_DRUID_GLYPH_OF_INNERVATE          = 54833,
     SPELL_DRUID_GLYPH_OF_STARFIRE           = 54846,
     SPELL_DRUID_INCREASED_MOONFIRE_DURATION = 38414,
-    SPELL_DRUID_LIFEBLOOM_ENERGIZE          = 64372,
     SPELL_DRUID_LIFEBLOOM_FINAL_HEAL        = 33778,
     SPELL_DRUID_LIFEBLOOM                   = 33763,
     SPELL_DRUID_LIVING_SEED_HEAL            = 48503,
@@ -457,14 +456,12 @@ public:
     {
         PrepareAuraScript(spell_dru_lifebloom_AuraScript);
 
-        /*bool Validate(SpellInfo const* spell) override
+        bool Validate(SpellInfo const* spell) override
         {
             if (!sSpellMgr->GetSpellInfo(SPELL_DRUID_LIFEBLOOM_FINAL_HEAL))
                 return false;
-            if (!sSpellMgr->GetSpellInfo(SPELL_DRUID_LIFEBLOOM_ENERGIZE))
-                return false;
             return true;
-        }*/
+        }
 
         void AfterRemove(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
         {


### PR DESCRIPTION
- Lifebloom now properly transfers stacks from previous target and removes aura as well.

- Tiger's Fury cast checks