### PR TITLE
Fix compile error AutoPtr

### DIFF
--- a/src/server/shared/Database/Transaction.h
+++ b/src/server/shared/Database/Transaction.h
@@ -7,7 +7,6 @@
 #define _TRANSACTION_H
 
 #include "SQLOperation.h"
-#include "AutoPtr.h"
 
 //- Forward declare (don't include header to prevent circular includes)
 class PreparedStatement;
@@ -39,7 +38,7 @@ class Transaction
         bool _cleanedUp;
 
 };
-typedef Skyfire::AutoPtr<Transaction, ACE_Thread_Mutex> SQLTransaction;
+typedef std::shared_ptr<Transaction> SQLTransaction;
 
 /*! Low level class*/
 class TransactionTask : public SQLOperation

--- a/src/server/shared/Database/Transaction.h
+++ b/src/server/shared/Database/Transaction.h
@@ -7,6 +7,7 @@
 #define _TRANSACTION_H
 
 #include "SQLOperation.h"
+#include "AutoPtr.h"
 
 //- Forward declare (don't include header to prevent circular includes)
 class PreparedStatement;


### PR DESCRIPTION
Fix error C2039: 'AutoPtr': is not a member of 'Skyfire'

Os: Win 11
VS: 2022
Cmake: 3.28.0