### PR TITLE
Fix compile error save tutorials in windows

### DIFF
--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -850,7 +850,7 @@ void WorldSession::SaveTutorialsData(SQLTransaction &trans)
 
     PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_HAS_TUTORIALS);
     stmt->setUInt32(0, GetAccountId());
-    bool hasTutorials = !CharacterDatabase.Query(stmt).null();
+    bool hasTutorials = CharacterDatabase.Query(stmt) != nullptr;
     // Modify data in DB
     stmt = CharacterDatabase.GetPreparedStatement(hasTutorials ? CHAR_UPD_TUTORIALS : CHAR_INS_TUTORIALS);
     for (uint8 i = 0; i < MAX_ACCOUNT_TUTORIAL_VALUES; ++i)


### PR DESCRIPTION
Error : Error    C2039    'null': is not a member of 'std::shared_ptr<PreparedResultSet>'    game    J:\Yekta-Core\Git\SkyFire.548\src\server\game\Server\WorldSession.cpp    853

Os: Win 11
VS: 2022
Cmake: 3.28.0
MySQL: 8.1