### PR TITLE
build fix for clang

### DIFF
--- a/cmake/compiler/clang/settings.cmake
+++ b/cmake/compiler/clang/settings.cmake
@@ -4,7 +4,7 @@
 #
 
 # Set build-directive (used in core to tell which buildtype we used)
-add_definitions(-D_BUILD_DIRECTIVE='"$(CONFIGURATION)"')
+add_definitions(-D_BUILD_DIRECTIVE='"${CMAKE_BUILD_TYPE}"')
 
 # Check C++20 compiler support
 include(CheckCXXCompilerFlag)


### PR DESCRIPTION
LDME 5 (Debian 11 bullseye) with clang 11