### PR TITLE
build fix for libmariadb

### DIFF
--- a/src/server/shared/Database/QueryResult.cpp
+++ b/src/server/shared/Database/QueryResult.cpp
@@ -36,7 +36,7 @@ m_length(NULL)
     }
 
     m_rBind = new MYSQL_BIND[m_fieldCount];
-    m_isNull = new bool[m_fieldCount];
+    m_isNull = new my_bool[m_fieldCount];
     m_length = new unsigned long[m_fieldCount];
 
     memset(m_isNull, 0, sizeof(bool) * m_fieldCount);

--- a/src/server/shared/Database/QueryResult.cpp
+++ b/src/server/shared/Database/QueryResult.cpp
@@ -36,7 +36,7 @@ m_length(NULL)
     }
 
     m_rBind = new MYSQL_BIND[m_fieldCount];
-    m_isNull = new my_bool[m_fieldCount];
+    m_isNull = new sql_bool[m_fieldCount];
     m_length = new unsigned long[m_fieldCount];
 
     memset(m_isNull, 0, sizeof(bool) * m_fieldCount);

--- a/src/server/shared/Database/QueryResult.cpp
+++ b/src/server/shared/Database/QueryResult.cpp
@@ -39,7 +39,7 @@ m_length(NULL)
     m_isNull = new sql_bool[m_fieldCount];
     m_length = new unsigned long[m_fieldCount];
 
-    memset(m_isNull, 0, sizeof(bool) * m_fieldCount);
+    memset(m_isNull, 0, sizeof(m_isNull[0]) * m_fieldCount);
     memset(m_rBind, 0, sizeof(MYSQL_BIND) * m_fieldCount);
     memset(m_length, 0, sizeof(unsigned long) * m_fieldCount);
 

--- a/src/server/shared/Database/QueryResult.h
+++ b/src/server/shared/Database/QueryResult.h
@@ -15,6 +15,7 @@
   #include <winsock2.h>
 #endif
 #include <mysql.h>
+using sql_bool = typename std::remove_pointer<decltype(std::declval<MYSQL_BIND>().is_null)>::type;
 
 class ResultSet
 {
@@ -82,7 +83,7 @@ class PreparedResultSet
         MYSQL_STMT* m_stmt;
         MYSQL_RES* m_res;
 
-        my_bool* m_isNull;
+        sql_bool* m_isNull;
         unsigned long* m_length;
 
         void FreeBindBuffer();

--- a/src/server/shared/Database/QueryResult.h
+++ b/src/server/shared/Database/QueryResult.h
@@ -82,7 +82,7 @@ class PreparedResultSet
         MYSQL_STMT* m_stmt;
         MYSQL_RES* m_res;
 
-        bool* m_isNull;
+        my_bool* m_isNull;
         unsigned long* m_length;
 
         void FreeBindBuffer();


### PR DESCRIPTION
Debian 11 has no libmysqlclient-dev repo

in libmariadb
``my_bool *is_null;``