### PR TITLE
undefined CR_INVALID_CONN_HANDLE by libmariadb

### DIFF
--- a/src/server/shared/Database/MySQLConnection.cpp
+++ b/src/server/shared/Database/MySQLConnection.cpp
@@ -468,7 +468,9 @@ bool MySQLConnection::_HandleMySQLErrno(uint32 errNo)
     {
         case CR_SERVER_GONE_ERROR:
         case CR_SERVER_LOST:
+#ifdef CR_INVALID_CONN_HANDLE
         case CR_INVALID_CONN_HANDLE:
+#endif
         case CR_SERVER_LOST_EXTENDED:
         {
             m_reconnecting = true;


### PR DESCRIPTION
Debian 11 has no libmysqlclient-dev repo