### PR TITLE
Fix pets/totems/guardians not tapping creatures they kill solo

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -904,9 +904,6 @@ void Creature::SetLootRecipient(Unit* unit)
         return;
     }
 
-    if (unit->GetTypeId() != TypeID::TYPEID_PLAYER && !unit->IsVehicle())
-        return;
-
     Player* player = unit->GetCharmerOrOwnerPlayerOrPlayerItself();
     if (!player)                                             // normal creature, no player involved
         return;


### PR DESCRIPTION
Fixes #1274

`Creature::SetLootRecipient` rejected any `Unit` that wasn't a `Player` or a vehicle before trying to resolve pet/totem/guardian ownership. `GetCharmerOrOwnerPlayerOrPlayerItself()` already handles that resolution correctly on its own (returns the owning player for a pet/totem/guardian, the player itself for a player, and `NULL` for a wild creature, which the very next line already handles). Dropping the redundant/incorrect type check lets a creature killed solely by a pet, totem or guardian get flagged as tapped/lootable, same as if the owning player had landed the hit directly.

Tested locally: compiles clean, boots clean, pets now correctly tap/loot creatures they kill solo.