### PR TITLE
Fix Runic Empowerment rune eligibility check

### DIFF
--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -151,7 +151,7 @@ public:
                     {
                         std::set<uint8> runes;
                         for (uint8 i = 0; i < MAX_RUNES; i++)
-                            if (_player->GetRuneCooldown(i) == _player->GetRuneBaseCooldown(i))
+                            if (_player->GetRuneCooldown(i) > 0)
                                 runes.insert(i);
                         if (!runes.empty())
                         {


### PR DESCRIPTION
Fixes #1270

`spell_dk_runic_empowerment_SpellScript::HandleOnHit` picked eligible runes by comparing `GetRuneCooldown(i) == GetRuneBaseCooldown(i)`, which is only true in the single instant a rune has just gone on cooldown. On every later tick the remaining cooldown is strictly less than the base cooldown, so this almost never found an eligible rune and the 45% proc rarely did anything in practice. Checking `GetRuneCooldown(i) > 0` instead correctly picks up any rune that's still recharging, regardless of how long ago it went on cooldown.