### PR TITLE
[Core/Spells] Fix Dash granting no speed bonus when auto-shifting into Cat Form

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraState.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraState.cpp
@@ -643,6 +643,24 @@ void AuraEffect::HandleAuraModShapeshift(AuraApplication const* aurApp, uint8 mo
                 target->ToPlayer()->RemoveTemporarySpell(shapeInfo->stanceSpell[i]);
         }
     }
+
+    // Some auras (e.g. Druid's Dash, spell 1850) gate their amount on the
+    // caster's CURRENT shapeshift form, calculated once when the aura first
+    // applies (AuraEffect::CalculateAmount) and never revisited afterward.
+    // That covers the case where such an aura is already active and the
+    // caster later leaves the form some other way (the aura should drop its
+    // bonus, but nothing tells it to re-check). The opposite case - the aura
+    // applying before entering the form - is handled at the point that aura
+    // itself applies (see spell_dru_dash's own AfterEffectApply hook for why
+    // that needs a separate fix); this one only needs to run when a form is
+    // actually being left, so applying auras aren't recalculated against a
+    // stale form here as well.
+    if (!apply)
+    {
+        Unit::AuraEffectList const speedAlwaysAuras(target->GetAuraEffectsByType(SPELL_AURA_MOD_SPEED_ALWAYS));
+        for (AuraEffect* speedAura : speedAlwaysAuras)
+            speedAura->RecalculateAmount();
+    }
 }
 
 void AuraEffect::HandleAuraTransform(AuraApplication const* aurApp, uint8 mode, bool apply) const

--- a/src/server/game/Spells/Auras/SpellAuraState.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraState.cpp
@@ -647,15 +647,12 @@ void AuraEffect::HandleAuraModShapeshift(AuraApplication const* aurApp, uint8 mo
     // Some auras (e.g. Druid's Dash, spell 1850) gate their amount on the
     // caster's CURRENT shapeshift form, calculated once when the aura first
     // applies (AuraEffect::CalculateAmount) and never revisited afterward.
-    // That covers the case where such an aura is already active and the
-    // caster later leaves the form some other way (the aura should drop its
-    // bonus, but nothing tells it to re-check). The opposite case - the aura
-    // applying before entering the form - is handled at the point that aura
-    // itself applies (see spell_dru_dash's own AfterEffectApply hook for why
-    // that needs a separate fix); this one only needs to run when a form is
-    // actually being left, so applying auras aren't recalculated against a
-    // stale form here as well.
-    if (!apply)
+    // Recalculate after the form has been set above so:
+    // - leaving Cat Form zeroes Dash's speed while the buff remains
+    // - re-entering Cat Form (or any form CalculateAmount cares about)
+    //   restores the bonus for the remaining duration
+    // Dash applying mid-cast before auto-shift is handled separately by
+    // spell_dru_dash's AfterEffectApply hook.
     {
         Unit::AuraEffectList const speedAlwaysAuras(target->GetAuraEffectsByType(SPELL_AURA_MOD_SPEED_ALWAYS));
         for (AuraEffect* speedAura : speedAlwaysAuras)

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -195,10 +195,28 @@ public:
                 amount = 0;
         }
 
+        // CalculateAmount() above only runs once, when this AuraEffect is first
+        // constructed - which happens while Dash's own spell is still being
+        // handled, effect by effect. When Dash is used from outside Cat Form,
+        // the client auto-shifts as part of casting it, but that shift is a
+        // second effect of the SAME cast that resolves AFTER this aura object
+        // already exists: the amount gets cached at 0 (still the old form) and
+        // is then pushed to the target using that stale value once this effect
+        // is actually applied - the buff icon shows up, but with no speed bonus,
+        // and nothing ever revisits it afterward. By the time this effect is
+        // actually applied to the target (AURA_EFFECT_HANDLE_REAL), the form
+        // change has already resolved, so re-checking it here and recalculating
+        // picks up the correct value.
+        void RecheckFormAfterApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+        {
+            GetEffect(EFFECT_0)->RecalculateAmount();
+        }
+
         void Register() override
         {
             // MoP Dash uses SPELL_AURA_MOD_SPEED_ALWAYS (129), not MOD_INCREASE_SPEED (31).
             DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_dru_dash_AuraScript::CalculateAmount, EFFECT_0, SPELL_AURA_MOD_SPEED_ALWAYS);
+            AfterEffectApply += AuraEffectApplyFn(spell_dru_dash_AuraScript::RecheckFormAfterApply, EFFECT_0, SPELL_AURA_MOD_SPEED_ALWAYS, AURA_EFFECT_HANDLE_REAL);
         }
     };
 


### PR DESCRIPTION
Fixes #1286.

## Root cause

When Dash is cast from outside Cat Form, the client auto-shifts as part of executing it, but that shift is a separate effect of the same spell cast that only resolves after Dash's own aura already exists. `AuraEffect`'s amount is calculated once at construction time (`spell_dru_dash`'s `CalculateAmount` reads `GetShapeshiftForm()` there and zeroes it if not Cat), and by the time the effect is actually applied to the target the cached amount is used as-is, with nothing to revisit it afterward. The buff icon shows up, but with no speed bonus, and it never corrects itself even once the caster is fully in Cat Form.

## Fix

- Added an `AfterEffectApply` hook (`AURA_EFFECT_HANDLE_REAL`) to `spell_dru_dash` that recalculates the amount right after the effect is applied — by then the shapeshift has already resolved, so the recheck picks up the correct form. Recalculating rather than special-casing the value also correctly pushes the updated speed to the client, since `AuraEffect::RecalculateAmount` re-invokes `HandleAuraModIncreaseSpeed` under `AURA_EFFECT_HANDLE_CHANGE_AMOUNT`.
- Also covered the opposite direction in `AuraEffect::HandleAuraModShapeshift`: if a `SPELL_AURA_MOD_SPEED_ALWAYS` aura is still active when its owner leaves a form, recalculate it too, since the same "computed once, never revisited" gap means such an aura would otherwise keep granting its bonus after the caster is no longer in the form that earned it.

## Testing

Reproduced the reported bug and verified the fix on a live test server: casting Dash from outside Cat Form (auto-shift) and from within it now grant the same speed bonus (confirmed via the client's movement speed percentage), matching the intended behavior.