### PR TITLE
Database: Fix invisible Corithras Moonrage in Dolanaar

### DIFF
--- a/sql/pending_updates/world/corithras_moonrage_invisible_dolanaar.sql
+++ b/sql/pending_updates/world/corithras_moonrage_invisible_dolanaar.sql
@@ -1,0 +1,10 @@
+-- Corithras Moonrage (entry 3515) is invisible in Dolanaar.
+--
+-- His Dolanaar spawn (guid 138764) carries aura 85813 in `creature_addon`. It is the only row
+-- in the world database referencing that spell. The aura hides the questgiver from players
+-- completely: the creature is spawned server side, but is never sent to the client, so it also
+-- never reaches the client's creaturecache.wdb. `.npc add 3515` produces a visible copy, since
+-- a fresh spawn has no `creature_addon` row.
+--
+-- Clear the aura only and leave the rest of the addon row untouched.
+UPDATE `creature_addon` SET `auras`=NULL WHERE `guid`=138764;


### PR DESCRIPTION
### Problem

Corithras Moonrage (entry 3515) never appears at his Dolanaar spawn point. He is spawned server side, but is never sent to the client.

His Dolanaar spawn, `creature` guid `138764`, has a `creature_addon` row applying aura **85813**:

```
guid    path_id  mount  bytes1  bytes2  emote  auras
138764  0        0      65536   257     0      85813
```

That aura hides the questgiver from players entirely. It is the only row in the world database referencing spell 85813:

```sql
SELECT COUNT(*) FROM `creature_addon` WHERE `auras`=85813;  -- 1
```

The row also ships in the current full DB release (`SFDB_full_548_26.001_2026_008_15_Release.sql`, line 426), so this reproduces on a clean install.

### How it was isolated

Everything else about the spawn is indistinguishable from neighbours that render correctly (Kal `3602`, Teldrassil Sentinel `3571`, several Wisps sharing the same guid block):

- `creature_template` 3515 is valid — `modelid1` 1528 has a `creature_model_info` row, faction 80, `npcflag` 2
- the `creature` row matches its neighbours field for field, including `spawnMask`, `phaseId`/`phaseGroup` and position/Z
- no `game_event_creature`, `pool_creature`, `creature_linked_respawn` or `smart_scripts` entries
- no pending `creature_respawn`, and nothing in `DBErrors.log`

`.npc add 3515` spawns a **visible** copy, because a fresh spawn has no `creature_addon` row. That isolates the addon as the cause.

Worth noting for anyone debugging something similar: because the creature is never sent to the client, it also never lands in the client's `creaturecache.wdb`, so its absence there is a symptom rather than a stale-cache problem. Also, neither `.go creature <guid>` nor `.list creature <id>` proves a creature is spawned — both read the `creature` table (`cs_list.cpp` does a plain `SELECT ... FROM creature`, despite the command help saying "found in world").

### Fix

Clear the aura only, leaving `bytes1`/`bytes2` and the rest of the addon row untouched:

```sql
UPDATE `creature_addon` SET `auras`=NULL WHERE `guid`=138764;
```

### Testing

Applied to a live 5.4.8 world database, worldserver restarted (there is no `.reload creature_addon`), and Corithras Moonrage now appears at his Dolanaar spawn and is targetable. Verified with exactly the statement in this PR — the surrounding addon fields were deliberately preserved rather than deleting the row.

Placed in `sql/pending_updates/world/` per that directory's README; the promotion workflow assigns the final `YYYY_MM_DD_world_NN.sql` name.
