### PR TITLE
Scripts: Implement Ireroot Seeds for quest "Nature's Reprisal"

### DIFF
--- a/sql/pending_updates/world/natures_reprisal_ireroot_seeds.sql
+++ b/sql/pending_updates/world/natures_reprisal_ireroot_seeds.sql
@@ -1,0 +1,15 @@
+-- Quest 13946 "Nature's Reprisal": Ireroot Seeds (item 46716) cast spell 65455, but nothing
+-- implemented the hit, so no credit for 34440 "Fel Rock Grellkin Kill Credit" was granted.
+-- Targets inside the quest POI polygon are Rascal Sprite (2002) and Shadow Sprite (2003).
+UPDATE `creature_template` SET `AIName`='SmartAI' WHERE `entry`=2003;
+
+DELETE FROM `smart_scripts` WHERE `source_type`=0 AND `entryorguid`=2002 AND `id` IN (1,2);
+DELETE FROM `smart_scripts` WHERE `source_type`=0 AND `entryorguid`=2003 AND `id` IN (0,1);
+
+INSERT INTO `smart_scripts`
+(`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,
+ `event_param1`,`event_param2`,`action_type`,`action_param1`,`target_type`,`comment`) VALUES
+(2002,0,1,2, 8,0,100,0,65455,0,33,34440,7,'Rascal Sprite - On spellhit Ireroot Seeds - Quest credit'),
+(2002,0,2,0,61,0,100,0,    0,0,37,    0,1,'Rascal Sprite - Linked - Die'),
+(2003,0,0,1, 8,0,100,0,65455,0,33,34440,7,'Shadow Sprite - On spellhit Ireroot Seeds - Quest credit'),
+(2003,0,1,0,61,0,100,0,    0,0,37,    0,1,'Shadow Sprite - Linked - Die');


### PR DESCRIPTION
### Problem

Quest **13946 "Nature's Reprisal"** asks the player to kill 12 Fel Rock grellkin using **Ireroot Seeds** (item `46716`). Using the item casts spell **65455**.

Nothing in the world database handles that spell:

- no row in `spell_script_names`
- no row in `smart_scripts` (searched every event and action parameter, not just the creatures involved)
- no row in `conditions`
- no row in `spell_linked_spell`

The throw is a client-side spell visual, so the seed appears to land, but the server does nothing on impact. No credit is granted for **34440 "Fel Rock Grellkin Kill Credit"**, the target does not die, and the quest cannot be completed.

### Targets

The quest POI polygon for objective 0 spans roughly x 10047-10174, y 1029-1122. The creatures spawned inside it are:

| entry | name | spawns | AIName |
| --- | --- | --- | --- |
| 2002 | Rascal Sprite | 9 | SmartAI |
| 2003 | Shadow Sprite | 9 | *(none)* |

Despite the objective wording, creature `1989 "Grellkin"` is not a target here - its nearest spawn is over 260 yards away, outside the polygon.

### Fix

Add SmartAI spellhit handlers to both creatures: on spell 65455, grant kill credit for 34440 to the caster, then kill the target. Shadow Sprite has no `AIName`, so it is set to `SmartAI`.

Rascal Sprite already has a script at id 0 (Faerie Fire), so the new rows use ids 1-2 and leave it untouched.

The linked `SMART_ACTION_DIE` is deliberate. Without it the sprite survives and a single mob can be farmed for all twelve credits.

### Testing

Applied to a live 5.4.8 world database. Before the change, throwing seeds at either sprite did nothing. After the change, the target dies, credit is granted, and the quest completes at 12.

### Known limitation

This restores the quest's function, not its presentation: the impact visual does not play on the target. That suggests retail drives the effect from the spell itself rather than from creature AI, so this should be treated as a working implementation rather than an exact reproduction. Happy to rework it if a spell-side hook is preferred.

Placed in `sql/pending_updates/world/` per that directory's README.
