### PR TITLE
Fix realm character sync to only rebuild local realms

### DIFF
--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -2961,44 +2961,48 @@ void World::SyncRealmCharacterCounts()
 {
     SF_LOG_INFO("server.loading", "Synchronizing realm character counts");
 
-    LoginDatabase.DirectExecute("UPDATE realmcharacters SET numchars = 0 WHERE realmid IN (SELECT id FROM realmlist)");
+    PreparedStatement* initStmt = LoginDatabase.GetPreparedStatement(LOGIN_INS_REALM_CHARACTERS_INIT);
+    LoginDatabase.DirectExecute(initStmt);
 
-    PreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_INS_REALM_CHARACTERS_INIT);
-    LoginDatabase.DirectExecute(stmt);
-
-    QueryResult result = CharacterDatabase.Query("SELECT account, realm, COUNT(guid) FROM characters WHERE account <> 0 AND deleteDate IS NULL GROUP BY account, realm");
-    if (!result)
+    for (std::map<uint32, std::string>::const_iterator realmItr = realmNameStore.begin(); realmItr != realmNameStore.end(); ++realmItr)
     {
-        SF_LOG_INFO("server.loading", "Synchronized 0 realm character count records");
-        return;
-    }
+        uint32 const realmId = realmItr->first;
 
-    uint32 count = 0;
-    SQLTransaction trans = LoginDatabase.BeginTransaction();
+        LoginDatabase.DirectPExecute("UPDATE realmcharacters SET numchars = 0 WHERE realmid = %u", realmId);
 
-    do
-    {
-        Field* fields = result->Fetch();
-        uint32 accountId = fields[0].GetUInt32();
-        uint32 realm = fields[1].GetUInt32();
-        uint8 charCount = uint8(fields[2].GetUInt64());
+        QueryResult result = CharacterDatabase.PQuery(
+            "SELECT account, COUNT(guid) FROM characters WHERE account <> 0 AND realm = %u AND deleteInfos_Name IS NULL GROUP BY account",
+            realmId);
 
-        if (realmNameStore.find(realm) == realmNameStore.end())
+        if (!result)
+        {
+            SF_LOG_INFO("server.loading", "Synchronized 0 realm character count records for realm %u (%s)", realmId, realmItr->second.c_str());
             continue;
+        }
 
-        stmt = LoginDatabase.GetPreparedStatement(LOGIN_UPD_REALM_CHARACTERS);
-        stmt->setUInt8(0, charCount);
-        stmt->setUInt32(1, accountId);
-        stmt->setUInt32(2, realm);
-        trans->Append(stmt);
-        ++count;
+        uint32 count = 0;
+        SQLTransaction trans = LoginDatabase.BeginTransaction();
+
+        do
+        {
+            Field* fields = result->Fetch();
+            uint32 accountId = fields[0].GetUInt32();
+            uint8 charCount = uint8(fields[1].GetUInt64());
+
+            PreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_UPD_REALM_CHARACTERS);
+            stmt->setUInt8(0, charCount);
+            stmt->setUInt32(1, accountId);
+            stmt->setUInt32(2, realmId);
+            trans->Append(stmt);
+            ++count;
+        }
+        while (result->NextRow());
+
+        if (count)
+            LoginDatabase.DirectCommitTransaction(trans);
+
+        SF_LOG_INFO("server.loading", "Synchronized %u realm character count records for realm %u (%s)", count, realmId, realmItr->second.c_str());
     }
-    while (result->NextRow());
-
-    if (count)
-        LoginDatabase.DirectCommitTransaction(trans);
-
-    SF_LOG_INFO("server.loading", "Synchronized %u realm character count records", count);
 }
 
 void World::InitWeeklyQuestResetTime()

--- a/src/tests/CharacterCreationRealmLimitTests.cpp
+++ b/src/tests/CharacterCreationRealmLimitTests.cpp
@@ -119,12 +119,13 @@ int main()
         "World startup should have a realm character count sync.");
     passed &= Expect(Contains(world, "SyncRealmCharacterCounts();"),
         "World startup should invoke the realm character count sync.");
-    passed &= Expect(Contains(syncRealmCharacterCounts, "UPDATE realmcharacters SET numchars = 0 WHERE realmid IN (SELECT id FROM realmlist)") &&
-        Contains(syncRealmCharacterCounts, "LOGIN_INS_REALM_CHARACTERS_INIT") &&
+    passed &= Expect(Contains(syncRealmCharacterCounts, "LOGIN_INS_REALM_CHARACTERS_INIT") &&
+        Contains(syncRealmCharacterCounts, "realmNameStore.begin()") &&
+        Contains(syncRealmCharacterCounts, "UPDATE realmcharacters SET numchars = 0 WHERE realmid = %u") &&
+        Contains(syncRealmCharacterCounts, "deleteInfos_Name IS NULL") &&
         Contains(syncRealmCharacterCounts, "if (count)") &&
-        Contains(syncRealmCharacterCounts, "LoginDatabase.DirectCommitTransaction(trans)") &&
-        Contains(syncRealmCharacterCounts, "SELECT account, realm, COUNT(guid) FROM characters WHERE account <> 0 AND deleteDate IS NULL GROUP BY account, realm"),
-        "World startup should rebuild realmcharacters from grouped character counts.");
+        Contains(syncRealmCharacterCounts, "LoginDatabase.DirectCommitTransaction(trans)"),
+        "World startup should rebuild realmcharacters per local realm without wiping other realms.");
     passed &= Expect(Contains(loginDatabase, "SELECT r.id, a.id, 0 FROM realmlist r CROSS JOIN account a LEFT JOIN realmcharacters rc ON rc.realmid = r.id AND rc.acctid = a.id WHERE rc.acctid IS NULL"),
         "Realm character init should create missing rows per account and per realm, not just per account.");
 


### PR DESCRIPTION
## Summary
- Per-realm character creation limits from PR #1297 are unchanged; this fixes startup `realmcharacters` sync.
- `SyncRealmCharacterCounts()` now resets and rebuilds counts only for realms owned by the running worldserver, instead of zeroing every realm in `realmlist` on boot.
- Uses `deleteInfos_Name IS NULL` to match character enum filtering.

## Why
When only one of several worldservers is online, the old global zero left other realms at `numchars = 0` until their worldservers booted. That broke auth realm-list counts and contributed to multi-realm character-select issues.

## Test plan
- [ ] Build worldserver
- [ ] Run `character_creation_realm_limit_tests`
- [ ] With 11 chars on realm A, create a character on realm B (should succeed)
- [ ] Boot one worldserver while others are offline; verify other realms keep correct auth counts
- [ ] Character select loads on each realm