### PR TITLE
Fix locked gameobject reloot exploit

### DIFF
--- a/src/server/game/Spells/SpellEffectsItems.cpp
+++ b/src/server/game/Spells/SpellEffectsItems.cpp
@@ -209,7 +209,7 @@ void Spell::EffectOpenLock(SpellEffIndex effIndex)
         if (player->OnArchaeologyFindUsed(gameObjTarget))
             return;
 
-        SendLoot(guid, LootType::LOOT_SKINNING);
+        SendLoot(guid, LootType::LOOT_CORPSE);
     }
     else if (itemTarget)
         itemTarget->SetFlag(ITEM_FIELD_DYNAMIC_FLAGS, ITEM_FLAG_UNLOCKED);


### PR DESCRIPTION
Spell::EffectOpenLock sent SendLoot(guid, LootType::LOOT_SKINNING) for
gameobject targets, but Player::SendLoot's respawn-time guard against
relooting an already-opened object only checks for LOOT_CORPSE. Any
gameobject with a LockId - not just chests, anything opened through
this effect - could be reopened and looted again immediately after
closing the loot window, even while the object was inside its normal
respawn cooldown, because the guard never ran. Reported against
"Galgar's Cactus Apple Surprise" (quest 25136), which could be looted
for an unlimited number of real, tradeable items.

Second commit adds a gameobject_loot_template entry that was missing
entirely for that same quest object, found while testing the fix.