### PR TITLE
[Core/LFG] Fix CMSG_LFD_TELEPORT opcode so leaving a dungeon works

### DIFF
--- a/src/server/game/Server/Protocol/Opcodes.cpp
+++ b/src/server/game/Server/Protocol/Opcodes.cpp
@@ -267,7 +267,7 @@ void OpcodeTable::InitializeClientTable()
     DEFINE_OPCODE_HANDLER(CMSG_LFD_LOCK_INFO_REQUEST,                   0x006B, STATUS_LOGGEDIN,                     PROCESS_THREADSAFE,   &WorldSession::HandleLFDGetLockInfoOpcode            ); // 5.4.8 18414
     DEFINE_OPCODE_HANDLER(CMSG_LFD_PROPOSAL_RESULT,                     0x1D9D, STATUS_LOGGEDIN,                     PROCESS_THREADUNSAFE, &WorldSession::HandleLfgProposalResultOpcode         ); // 5.4.8 18414
     DEFINE_OPCODE_HANDLER(CMSG_LFD_SET_BOOT_VOTE,                       0x17BE, STATUS_LOGGEDIN,                     PROCESS_THREADUNSAFE, &WorldSession::HandleLFDSetBootVoteOpcode            ); // 5.4.8 18414
-    DEFINE_OPCODE_HANDLER(CMSG_LFD_TELEPORT,                            0x1AA6, STATUS_LOGGEDIN,                     PROCESS_THREADUNSAFE, &WorldSession::HandleLFDTeleportOpcode               ); // 5.4.8 18414
+    DEFINE_OPCODE_HANDLER(CMSG_LFD_TELEPORT,                            0x178A, STATUS_LOGGEDIN,                     PROCESS_THREADUNSAFE, &WorldSession::HandleLFDTeleportOpcode               ); // 5.4.8 18414
     DEFINE_OPCODE_HANDLER(CMSG_LFG_GET_STATUS,                          0x032D, STATUS_LOGGEDIN,                     PROCESS_THREADSAFE,   &WorldSession::HandleLfgGetStatus                    ); // 5.4.8 18414
     DEFINE_OPCODE_HANDLER(CMSG_LFG_SET_ROLES,                           0x08A2, STATUS_LOGGEDIN,                     PROCESS_THREADUNSAFE, &WorldSession::HandleLfgSetRolesOpcode               ); // 5.4.8 18414
     DEFINE_OPCODE_HANDLER(CMSG_LF_GUILD_ADD_APPLICATION,                0x0C63, STATUS_LOGGEDIN,                     PROCESS_THREADUNSAFE, &WorldSession::HandleGuildFinderAddApplication       ); // 5.4.8 18414


### PR DESCRIPTION
### What

`CMSG_LFD_TELEPORT` is registered at `0x1AA6`. The 5.4.8 client sends it at `0x178A`, so the request never reaches `HandleLFDTeleportOpcode` and is dropped as an unhandled opcode.

### How it was found

Logged the size and payload of unhandled opcodes while clicking the minimap eye to leave a dungeon on 5.4.8 build 18414. The client sends opcode `0x178A` with a one byte payload, which is exactly what the existing handler reads:

```cpp
void WorldSession::HandleLFDTeleportOpcode(WorldPacket& recvData)
{
    bool out;
    recvData >> out;
    sLFGMgr->TeleportPlayer(GetPlayer(), out, true);
}
```

The handler itself was already correct and simply never ran.

### Effect

Without this the player never gets teleported out through the minimap eye, and the dungeon finder is left showing a paused queue that refuses a new one until the character relogs.

Fixing the opcode alone is not enough to clear that paused state; the queue side of it is a separate problem and is not part of this pull request.

### Tested

5.4.8 build 18414, enUS client. Queue for a random dungeon, enter, click the minimap eye, leave.