### PR TITLE
[Core/LFG] Fix dungeon finder stuck paused after leaving a dungeon

### DIFF
--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -835,6 +835,19 @@ namespace lfg
         }
     }
 
+    void LFGMgr::RemoveStaleQueueEntry(uint64 guid, uint32 queueId)
+    {
+        LFGQueue& queue = GetQueueById(uint8(queueId));
+        if (!queue.HasQueueData(guid))
+            return;
+
+        SF_LOG_DEBUG("lfg", "Player: %u had a queue entry with no matching state, removed from queue %u.",
+            GUID_LOPART(guid), queueId);
+
+        queue.RemoveFromQueue(guid);
+        SendLfgUpdateStatus(guid, LfgUpdateData(LFG_UPDATETYPE_REMOVED_FROM_QUEUE), false);
+    }
+
     void LFGMgr::LeaveSoloLfg(uint64 guid, uint32 queueId, bool disconnected)
     {
         SF_LOG_DEBUG("lfg.leave", "Player: %u left queue.", GUID_LOPART(guid));
@@ -844,7 +857,11 @@ namespace lfg
         {
             case LFG_STATE_QUEUED:
             {
-                LFGQueue& queue = GetQueue(queueId);
+                // GetQueueById, not GetQueue: the id is already at hand here.
+                // GetQueue takes the guid of whoever is queued and resolves the
+                // id itself, so handing it an id compiles and removes from an
+                // unrelated queue, leaving the player's own entry untouched.
+                LFGQueue& queue = GetQueueById(uint8(queueId));
                 queue.RemoveFromQueue(guid);
                 SendLfgUpdateStatus(guid, LfgUpdateData(LFG_UPDATETYPE_REMOVED_FROM_QUEUE), false);
                 ClearQueueState(guid, "Leave queued solo player");
@@ -873,12 +890,22 @@ namespace lfg
             }
             case LFG_STATE_NONE:
             case LFG_STATE_RAIDBROWSER:
+            {
+                // State saying nothing is going on does not mean the queue is
+                // clean. The queue entry and the player state are stored apart,
+                // and after leaving a dungeon the state is cleared while the
+                // entry survives. When it does, the queue keeps sending status
+                // updates with the timer running and the client stays on a
+                // paused queue no matter how often the player asks to leave.
+                RemoveStaleQueueEntry(guid, queueId);
                 break;
+            }
             case LFG_STATE_DUNGEON:
             case LFG_STATE_FINISHED_DUNGEON:
             case LFG_STATE_BOOT:
             {
                 ClearQueueState(guid, "Leave solo dungeon player");
+                RemoveStaleQueueEntry(guid, queueId);
                 break;
             }
         }

--- a/src/server/game/DungeonFinding/LFGMgr.h
+++ b/src/server/game/DungeonFinding/LFGMgr.h
@@ -470,6 +470,10 @@ namespace lfg
         void SetState(uint64 guid, LfgState state);
         void SetVoteKick(uint64 guid, bool active);
         void RemovePlayerData(uint64 guid);
+        /// Drops a queue entry left behind without a matching player state.
+        /// Without it the queue keeps sending status updates to someone who
+        /// already left.
+        void RemoveStaleQueueEntry(uint64 guid, uint32 queueId);
         void GetCompatibleDungeons(LfgDungeonSet& dungeons, LfgGuidSet const& players, LfgLockPartyMap& lockMap, bool isContinue);
         void _SaveToDB(uint64 guid, uint32 db_guid);
         LFGDungeonData const* GetLFGDungeon(uint32 id);
@@ -480,6 +484,13 @@ namespace lfg
 
         // Generic
         LFGQueue& GetQueue(uint64 guid);
+        /// Looks a queue up by its own id.
+        ///
+        /// GetQueue above takes the guid of whoever sits in the queue and
+        /// resolves the id from it. Passing a queue id to that overload still
+        /// compiles, since both are integers, and quietly returns a different
+        /// queue.
+        LFGQueue& GetQueueById(uint8 queueId) { return QueuesStore[queueId]; }
 
         LfgDungeonSet const& GetDungeonsByRandom(uint32 randomdungeon);
         LfgType GetDungeonType(uint32 dungeon);

--- a/src/server/game/Handlers/LFGHandler.cpp
+++ b/src/server/game/Handlers/LFGHandler.cpp
@@ -180,7 +180,7 @@ void WorldSession::HandleLfgLeaveOpcode(WorldPacket& recvData)
         SF_LOG_DEBUG("lfg.leave", "CMSG_LFD_LEAVE Player: %lu left solo queue ticket type %u id %u time %u slot %u.",
             guid, ticketType, ticketId, ticketTime, slotOrQueueId);
         sLFGMgr->LeaveSoloLfg(guid, activeQueueId);
-        SendLfgClearStatus(0, queueID, clientTicketLeave);
+        SendLfgClearStatus(0, queueID, clientTicketLeave, ticketTime);
         return;
     }
 
@@ -201,7 +201,18 @@ void WorldSession::HandleLfgLeaveOpcode(WorldPacket& recvData)
 
     if (disbandDungeonGroup)
     {
+        uint8 const groupQueueId = sLFGMgr->GetQueueId(groupGuid);
+
         group->Disband();
+
+        // The cleanup sent while disbanding walks the player list the dungeon
+        // finder keeps for the group, and that list is already being torn down,
+        // so whoever asked to leave may get nothing. Answering here costs one
+        // packet and closes the gap. The ticket echoed back is the one the
+        // request carried: inside the dungeon the queue entry no longer exists
+        // on this side, so anything looked up here would go out as zero and be
+        // discarded by the client.
+        SendLfgClearStatus(0, groupQueueId ? groupQueueId : queueID, clientTicketLeave, ticketTime);
         return;
     }
 
@@ -215,7 +226,7 @@ void WorldSession::HandleLfgLeaveOpcode(WorldPacket& recvData)
 
     SF_LOG_DEBUG("lfg.leave", "CMSG_LFD_LEAVE GroupLeader: %lu left group queue.", guid);
     sLFGMgr->LeaveLfg(groupGuid);
-    SendLfgClearStatus(0, queueID, clientTicketLeave);
+    SendLfgClearStatus(0, queueID, clientTicketLeave, ticketTime);
 }
 
 void WorldSession::HandleLfgProposalResultOpcode(WorldPacket& recvData)
@@ -590,7 +601,7 @@ void WorldSession::HandleLfgGetStatus(WorldPacket& /*recvData*/)
         sLFGMgr->SendActiveProposal(guid);
 }
 
-void WorldSession::SendLfgUpdateStatus(lfg::LfgUpdateData const& updateData, bool party, uint64 queueGuidOverride, uint8 queueIdOverride)
+void WorldSession::SendLfgUpdateStatus(lfg::LfgUpdateData const& updateData, bool party, uint64 queueGuidOverride, uint8 queueIdOverride, uint32 joinTimeOverride)
 {
     bool join = false;
     bool queued = false;
@@ -615,6 +626,14 @@ void WorldSession::SendLfgUpdateStatus(lfg::LfgUpdateData const& updateData, boo
         queueId = sLFGMgr->GetQueueId(queueGuid);
     if (queueIdOverride)
         queueId = queueIdOverride;
+    // The client matches an update against its queue by a three field ticket,
+    // and the join time is one of those fields. Once the dungeon starts the
+    // queue entry is already gone, so GetQueueJoinTime returns zero and every
+    // update leaves with a ticket the client cannot recognize as its own. The
+    // caller passes back the time the client itself sent, which is the only
+    // copy still around.
+    if (joinTimeOverride)
+        joinTime = time_t(joinTimeOverride);
     uint8 dungeonCategory = 0;
     std::vector<uint32> dungeonEntries;
     dungeonEntries.reserve(updateData.dungeons.size());
@@ -1045,14 +1064,14 @@ void WorldSession::SendLfgLfrList(bool update)
     SendPacket(&data);
 }
 
-void WorldSession::SendLfgClearStatus(uint64 lfgGroupGuid, uint8 queueIdOverride, bool groupLeave)
+void WorldSession::SendLfgClearStatus(uint64 lfgGroupGuid, uint8 queueIdOverride, bool groupLeave, uint32 joinTimeOverride)
 {
     if (groupLeave)
-        SendLfgUpdateStatus(lfg::LfgUpdateData(lfg::LFG_UPDATETYPE_LEADER_UNK1), true, lfgGroupGuid, queueIdOverride);
+        SendLfgUpdateStatus(lfg::LfgUpdateData(lfg::LFG_UPDATETYPE_LEADER_UNK1), true, lfgGroupGuid, queueIdOverride, joinTimeOverride);
 
     lfg::LfgUpdateData removed(lfg::LFG_UPDATETYPE_REMOVED_FROM_QUEUE);
-    SendLfgUpdateStatus(removed, false, 0, queueIdOverride);
-    SendLfgUpdateStatus(removed, true, lfgGroupGuid, queueIdOverride);
+    SendLfgUpdateStatus(removed, false, 0, queueIdOverride, joinTimeOverride);
+    SendLfgUpdateStatus(removed, true, lfgGroupGuid, queueIdOverride, joinTimeOverride);
     SendLfgLfrList(false);
 }
 

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -947,10 +947,10 @@ public:                                                 // opcodes handlers
     void HandleChallengeModeRequestLeaders(WorldPacket& recvData);
     void HandleChallengeModeRequestMapStats(WorldPacket& recvData);
 
-    void SendLfgUpdateStatus(lfg::LfgUpdateData const& updateData, bool party, uint64 queueGuidOverride = 0, uint8 queueIdOverride = 0);
+    void SendLfgUpdateStatus(lfg::LfgUpdateData const& updateData, bool party, uint64 queueGuidOverride = 0, uint8 queueIdOverride = 0, uint32 joinTimeOverride = 0);
     void SendLfgRoleChosen(uint64 guid, uint8 roles);
     void SendLfgRoleCheckUpdate(lfg::LfgRoleCheck const& pRoleCheck);
-    void SendLfgClearStatus(uint64 lfgGroupGuid = 0, uint8 queueIdOverride = 0, bool groupLeave = false);
+    void SendLfgClearStatus(uint64 lfgGroupGuid = 0, uint8 queueIdOverride = 0, bool groupLeave = false, uint32 joinTimeOverride = 0);
     void SendLfgLfrList(bool update);
     void SendLfgJoinResult(lfg::LfgJoinResultData const& joinData);
     void SendLfgQueueStatus(lfg::LfgQueueStatusData const& queueData);


### PR DESCRIPTION
### Symptom

After leaving a dungeon, the dungeon finder stays on a paused queue and refuses to queue again. Clicking leave any number of times changes nothing. Going back to character select and logging in again clears it, because the login path runs the same cleanup with no group attached and it finally succeeds.

Three separate defects stack up here, and each one hides the next.

### 1. Leaving removed from the wrong queue

`LeaveSoloLfg` receives a queue id and did:

```cpp
LFGQueue& queue = GetQueue(queueId);
```

`GetQueue` takes the guid of whoever sits in the queue and resolves the id itself. Both parameters are integers, so passing an id compiles fine and quietly returns a different queue. The removal hit that unrelated queue while the player's own entry stayed put.

Added `GetQueueById` for callers that already hold the id, and used it here.

### 2. The queue entry outlived the player state

The removal switch only acted on `LFG_STATE_QUEUED` and `LFG_STATE_PROPOSAL`. Coming out of a dungeon the state is already cleared, so:

```cpp
case LFG_STATE_NONE:
case LFG_STATE_RAIDBROWSER:
    break;
```

The one code path able to drop the queue entry gave up exactly where it was needed. The entry survived, and the queue kept sending status updates with the timer running. `RemoveStaleQueueEntry` now drops an entry that has no matching state.

### 3. The leave notification went out without a ticket

This is what kept the client stuck even with the two above fixed.

The client matches an incoming `SMSG_LFD_UPDATE_STATUS` against its own queue by a three field ticket, and the join time is one of the three fields. `SendLfgUpdateStatus` fills that field from `GetQueueJoinTime`, but inside a dungeon the queue entry no longer exists on the server side, so the lookup returns zero and the client discards an update it cannot recognize as its own.

Captured on the wire: entering the queue the update carries `UnixTime 1788441513`, while every update sent on leave carries `UnixTime 0`.

The reply now echoes back the ticket that came in with the leave request, which is the only copy still around at that point. `SendLfgUpdateStatus` and `SendLfgClearStatus` take an optional `joinTimeOverride` for that.

### Note

Leaving through the minimap eye also needs #1396, otherwise the request never reaches the server at all. The two are independent in code and can be merged in either order.

### Tested

5.4.8 build 18414, enUS client. Queue solo for a random dungeon, enter, leave, queue again without relogging. Also checked leaving the queue before a group forms and leaving a queued group as leader.