### PR TITLE
SQL: Remove duplicate spawns of unique named NPCs

### DIFF
--- a/sql/pending_updates/world/remove_duplicate_named_npc_spawns.sql
+++ b/sql/pending_updates/world/remove_duplicate_named_npc_spawns.sql
@@ -1,0 +1,20 @@
+-- Remove duplicate spawns of unique named NPCs (issues #1339 and #1349).
+--
+-- Chef Grual (272), Farrin Daris (2112), Avette Fellwood (228) and Watcher Bukouris (494)
+-- are each spawned twice in Stormwind, a few yards apart. The second copy of each sits in
+-- the guid block 192400-192600, which is an ambient wildlife import (rats, frogs, roaches,
+-- skunks). That import also pulled in these four named NPCs, which already existed at their
+-- original guids 5745, 5761, 5763 and 5767. The other named NPCs inside the same block
+-- (Egan, Augustus the Touched, Frax Bucketdrop, Fiona) only have a single spawn each and are
+-- left untouched.
+--
+-- Nipsy (13018) in the Deeprun Tram has the same problem: guid 52990 belongs to the coherent
+-- Deeprun Rat Roundup set (Deeprun Rat 13016 at guid 52988, Enthralled Deeprun Rat 13017 at
+-- guid 52989), while guid 58 landed in a low guid range that was refilled later (its
+-- neighbours 59-62 are Sandstone Earthen, a Cataclysm NPC) and carries spawntimesecs 7200
+-- instead of the 180 used by the original row.
+--
+-- None of the removed guids is referenced by creature_addon, smart_scripts, pool_creature,
+-- game_event_creature, linked_respawn or creature_formations.
+
+DELETE FROM `creature` WHERE `guid` IN (192456, 192457, 192458, 192463, 58);


### PR DESCRIPTION
Fixes #1339 and #1349.

### What is wrong

Five unique named NPCs have two spawns each, standing a few yards apart:

| NPC | entry | original guid | duplicate guid | distance |
|---|---|---|---|---|
| Chef Grual | 272 | 5767 | 192457 | 3.6 yd |
| Farrin Daris | 2112 | 5763 | 192456 | 15.8 yd |
| Avette Fellwood | 228 | 5761 | 192458 | 8.5 yd |
| Watcher Bukouris | 494 | 5745 | 192463 | 3.8 yd |
| Nipsy | 13018 | 52990 | 58 | 3.4 yd |

Only Chef Grual (#1339) and Nipsy (#1349) were reported, but the other three come from the same defect and are included here.

### How the duplicates were identified

For the four Stormwind NPCs, the extra rows all live in the guid block 192400-192600. That block is an ambient wildlife import (rats, frogs, roaches, skunks, spiders), and it swept in four named NPCs that already existed at their original low guids. The other named NPCs inside the same block (Egan, Augustus the Touched, Frax Bucketdrop, Fiona) have a single spawn each and are deliberately left untouched.

For Nipsy, guid 52990 belongs to the coherent Deeprun Rat Roundup set: Deeprun Rat (13016) at guid 52988 and Enthralled Deeprun Rat (13017) at guid 52989. Guid 58 landed in a low guid range that was refilled later, its neighbours 59-62 being Sandstone Earthen, a Cataclysm NPC, and it carries spawntimesecs 7200 against the 180 of the original row.

### Safety checks

None of the removed guids is referenced by `creature_addon`, `smart_scripts` (guid based, negative entryorguid), `pool_creature`, `game_event_creature`, `linked_respawn` or `creature_formations`.

### Testing

Applied against a local 5.4.8 world database. Before the update each of the five entries had 2 spawns; after it each has exactly 1, and the surviving row is the original guid in every case.

If you have sniff data showing that a different row of any pair is the authentic one, the fix is a one line change of which guid gets removed.